### PR TITLE
avoid outdated links to science-to-touch

### DIFF
--- a/apps/beat_box/app.json
+++ b/apps/beat_box/app.json
@@ -3,7 +3,7 @@
   "version": "",
   "type": "remote",
   "main": "lalalab-launcher",
-  "lalalabDemoHref": "http://science-to-touch.com/LaLaLab/lalalab-apps/applauncher2/?cfg=beatbox",
+  "lalalabDemoHref": "https://cindyjs.github.io/lalalab-apps/applauncher2/?cfg=beatbox",
   "name": "Beat Box",
   "description": {}
 }

--- a/apps/show_me_music/app.json
+++ b/apps/show_me_music/app.json
@@ -3,7 +3,7 @@
   "version": "",
   "type": "remote",
   "main": "lalalab-launcher",
-  "lalalabDemoHref": "http://science-to-touch.com/LaLaLab/lalalab-apps/applauncher2/?cfg=showmemusic",
+  "lalalabDemoHref": "https://cindyjs.github.io/lalalab-apps/applauncher2/?cfg=showmemusic#",
   "name": "Show Me Music",
   "description": {}
 }


### PR DESCRIPTION
I created a current version of BeatBox and ShowMeMusic hosted through gh-pages. 